### PR TITLE
Added capability to use different credentials for different vCenter S…

### DIFF
--- a/settings.example.py
+++ b/settings.example.py
@@ -12,10 +12,8 @@ VC_HOSTS = [
     # Hostname (FQDN or IP) and port used to access vCenter cluster
     # You can add more vCenter instances by duplicating the line below and
     # updating the values
-    {"HOST": "vcenter1.example.com", "PORT": 443},
+    {"HOST": "vcenter1.example.com", "PORT": 443, "USER": "", "PASS": ""},
     ]
-VC_USER = "" # User account to authenticate to vCenter, supports SSO with @domain.tld suffix
-VC_PASS = "" # Password for the account defined in VC_USER
 
 # NetBox Settings
 NB_API_KEY = "" # NetBox API Key


### PR DESCRIPTION
### Added capability to use different credentials for different vCenter Servers

In settings.py you need add follow lines (for example):
```
# vCenter Settings
VC_HOSTS = [
    # Hostname (FQDN or IP) and port used to access vCenter cluster
    # You can add more vCenter instances by duplicating the line below and
    # updating the values
    {"HOST": "vcenter1.example.com", "PORT": 443, "USER": "", "PASS": ""},
    {"HOST": "vcenter2.example.com", "PORT": 443, "USER": "", "PASS": ""},
    ]
```
