### PR TITLE
Fix for #33 by filtering prunable virtual interfaces post collection from NetBox

### DIFF
--- a/run.py
+++ b/run.py
@@ -998,6 +998,10 @@ class NetBoxHandler:
                     obj for obj in nb_objects
                     if self.vc_tag in obj["tags"]
                     ]
+                log.debug(
+                    "Found %s virtual interfaces with tag '%s'.",
+                    len(nb_objects), self.vc_tag
+                    )
             elif vc_obj_type == "virtual_machines" and \
                     nb_obj_type == "ip_addresses":
                 nb_objects = [


### PR DESCRIPTION
With the current design of NetBox we are able to apply tags to device component models but we are not able to query for them by the tags. This workaround leverages the tags post collection from NetBox to filter to our desired objects.