### PR TITLE
Specify a VRF in settings.py Implementation

### DIFF
--- a/run.py
+++ b/run.py
@@ -905,7 +905,7 @@ class NetBoxHandler:
                 },
             }
         self.vc_tag = format_tag(vc_conn["HOST"])
-        self.vrf_id = vc_conn["VRF_ID"]
+        self.vrf_id = vc_conn.get("VRF_ID")
         self.vc = vCenterHandler(
             format_vcenter_conn(vc_conn), nb_api_version=self.nb_api_version
             )

--- a/run.py
+++ b/run.py
@@ -905,6 +905,7 @@ class NetBoxHandler:
                 },
             }
         self.vc_tag = format_tag(vc_conn["HOST"])
+        self.vrf_id = vc_conn["VRF_ID"]
         self.vc = vCenterHandler(
             format_vcenter_conn(vc_conn), nb_api_version=self.nb_api_version
             )

--- a/run.py
+++ b/run.py
@@ -1519,9 +1519,9 @@ class NetBoxHandler:
         :rtype: dict
         """
         result = {"tenant": None, "vrf": None}
-        query = ("?contains={}".format(ip_addr) 
-                if self.vrf_id is None 
-                else "?contains={}&vrf_id={}".format(ip_addr, self.vrf_id))
+        query = ("?contains={}".format(ip_addr)
+                 if self.vrf_id is None
+                 else "?contains={}&vrf_id={}".format(ip_addr, self.vrf_id))
         try:
             prefix_obj = self.request(
                 req_type="get", nb_obj_type="prefixes", query=query

--- a/run.py
+++ b/run.py
@@ -1100,6 +1100,8 @@ class NetBoxHandler:
                 quote_plus(vc_data["virtual_machine"]["name"]), query_key,
                 vc_data[query_key]
                 )
+        elif self.vrf_id is not None and nb_obj_type in ("ip_addresses", "prefixes"):
+            query = "?{}={}&vrf_id={}".format(query_key, vc_data[query_key], self.vrf_id)
         else:
             query = "?{}={}".format(
                 query_key, vc_data[query_key]
@@ -1516,7 +1518,9 @@ class NetBoxHandler:
         :rtype: dict
         """
         result = {"tenant": None, "vrf": None}
-        query = "?contains={}".format(ip_addr)
+        query = ("?contains={}".format(ip_addr) 
+                if self.vrf_id is None 
+                else "?contains={}&vrf_id={}".format(ip_addr, self.vrf_id))
         try:
             prefix_obj = self.request(
                 req_type="get", nb_obj_type="prefixes", query=query

--- a/settings.example.py
+++ b/settings.example.py
@@ -33,7 +33,7 @@ DEVICE_ROLE = "Server"
 # The USER argument supports SSO with @domain.tld suffix
 VC_HOSTS = [
     # You can add more vCenter instances by duplicating the line below
-    {"HOST": "vcenter1.example.com", "PORT": 443, "USER": "", "PASS": ""},
+    {"HOST": "vcenter1.example.com", "PORT": 443, "USER": "", "PASS": "", "VRF_ID": None},
     ]
 
 


### PR DESCRIPTION
Implementation of [Specify a VRF in settings.py #101](https://github.com/synackray/vcenter-netbox-sync/issues/101)

Added "VRF_ID" option to the VC_HOSTS settings entry.
If not None this id is used as filter condition for IPs