### PR TITLE
Sync VM comments

### DIFF
--- a/run.py
+++ b/run.py
@@ -711,6 +711,7 @@ class vCenterHandler:
                     results["virtual_machines"].append(nbt.virtual_machine(
                         name=truncate(obj_name, max_len=64),
                         cluster=cluster,
+                        comments=getattr(obj.config, "annotation", None),
                         status=int(
                             1 if obj.runtime.powerState == "poweredOn" else 0
                             ),

--- a/templates/netbox.py
+++ b/templates/netbox.py
@@ -625,7 +625,7 @@ class Templates:
             "vcpus": vcpus,
             "memory": memory,
             "disk": disk,
-            "comments": comments,
+            "comments": comments.replace("\n", "\r\n\r") if comments else None,
             "local_context_data": local_context_data,
             "tags": tags
             }


### PR DESCRIPTION
Implementation for [Add notes and tags field of VM from vCenter to Netbox #57](https://github.com/synackray/vcenter-netbox-sync/issues/57)

vm.config.annotation is synced as comment to netbox

Possible drawback: Manually edited Comments in Netbox get overwritten with each sync