### PR TITLE
Removed duplicate vm Logging

### DIFF
--- a/run.py
+++ b/run.py
@@ -683,10 +683,6 @@ class vCenterHandler:
                             tags=self.tags,
                             ))
                 elif vc_obj_type == "virtual_machines":
-                    log.info(
-                        "Collecting info about vCenter %s '%s' object.",
-                        vc_obj_type, obj_name
-                        )
                     # Virtual Machines
                     log.debug(
                         "Collecting info for virtual machine '%s'", obj_name


### PR DESCRIPTION
same log statement already present at the start of the loop.
Fix for [VMs have duplicated log.info() call #120](https://github.com/synackray/vcenter-netbox-sync/issues/120)