### PR TITLE
Strip whitespaces when checking if asset tag is banned

### DIFF
--- a/run.py
+++ b/run.py
@@ -204,11 +204,11 @@ def is_banned_asset_tag(text):
     # Is asset tag in banned list?
     text = text.lower()
     banned_tags = [
-        "Default string", "NA", "N/A", "None", " none", "Null", "oem", "o.e.m",
+        "Default string", "NA", "N/A", "None", "Null", "oem", "o.e.m",
         "to be filled by o.e.m.", "Unknown", " ", ""
         ]
     banned_tags = [t.lower() for t in banned_tags]
-    if text in banned_tags:
+    if text.strip() in banned_tags:
         result = True
     # Does it exceed the max allowed length for NetBox asset tags?
     elif len(text) > 50:


### PR DESCRIPTION
Sometimes vCenter returns asset tags with a leading whitespace. Instead of adding a second version with a whitespace to the banned tags list we use the strip() method to remove the whitespace before checking.