### PR TITLE
strip whitespace from platform name

### DIFF
--- a/run.py
+++ b/run.py
@@ -708,23 +708,41 @@ class vCenterHandler:
                             results["platforms"].append(nbt.platform(
                                 name=platform,
                                 ))
-                    results["virtual_machines"].append(nbt.virtual_machine(
-                        name=truncate(obj_name, max_len=64),
-                        cluster=cluster,
-                        status=int(
-                            1 if obj.runtime.powerState == "poweredOn" else 0
-                            ),
-                        role="Server",
-                        platform=platform,
-                        memory=obj.config.hardware.memoryMB,
-                        disk=int(sum([
-                            comp.capacityInKB for comp in
-                            obj.config.hardware.device
-                            if isinstance(comp, vim.vm.device.VirtualDisk)
-                            ]) / 1024 / 1024),  # Kilobytes to Gigabytes
-                        vcpus=obj.config.hardware.numCPU,
-                        tags=self.tags
-                        ))
+                        results["virtual_machines"].append(nbt.virtual_machine(
+                            name=truncate(obj_name, max_len=64),
+                            cluster=cluster,
+                            status=int(
+                                1 if obj.runtime.powerState == "poweredOn" else 0
+                                ),
+                            role="Server",
+                            platform=platform.strip(),
+                            memory=obj.config.hardware.memoryMB,
+                            disk=int(sum([
+                                comp.capacityInKB for comp in
+                                obj.config.hardware.device
+                                if isinstance(comp, vim.vm.device.VirtualDisk)
+                                ]) / 1024 / 1024),  # Kilobytes to Gigabytes
+                            vcpus=obj.config.hardware.numCPU,
+                            tags=self.tags
+                            ))
+                    else:
+                        results["virtual_machines"].append(nbt.virtual_machine(
+                            name=truncate(obj_name, max_len=64),
+                            cluster=cluster,
+                            status=int(
+                                1 if obj.runtime.powerState == "poweredOn" else 0
+                                ),
+                            role="Server",
+                            platform=platform,
+                            memory=obj.config.hardware.memoryMB,
+                            disk=int(sum([
+                                comp.capacityInKB for comp in
+                                obj.config.hardware.device
+                                if isinstance(comp, vim.vm.device.VirtualDisk)
+                                ]) / 1024 / 1024),  # Kilobytes to Gigabytes
+                            vcpus=obj.config.hardware.numCPU,
+                            tags=self.tags
+                            ))
                     # If VMware Tools is not detected then we cannot reliably
                     # collect interfaces and IP addresses
                     if platform:


### PR DESCRIPTION
The guestOS reported by VMware vSphere API can sometimes contain a trailing whitespace.
For example "Linux 4.18.0-147.8.1.el8_1.x86_64 CentOS Linux release 8.1.1911 (Core) "

This causes problems, more information on this is described in https://github.com/netbox-community/netbox/issues/4974
I propose to strip the trailing whitespace from the platform name, if its value is not empty.