### PR TITLE
Remove itype from vm_interface

### DIFF
--- a/run.py
+++ b/run.py
@@ -663,7 +663,6 @@ class vCenterHandler:
                         results["interfaces"].append(nbt.device_interface(
                             device=truncate(obj_name, max_len=64),
                             name=nic_name,
-                            itype=0,  # Virtual
                             mac_address=vnic.spec.mac,
                             mtu=vnic.spec.mtu,
                             tags=self.tags,
@@ -738,7 +737,6 @@ class vCenterHandler:
                             results["virtual_interfaces"].append(
                                 nbt.vm_interface(
                                     virtual_machine=obj_name,
-                                    itype=0,
                                     name=nic_name,
                                     mac_address=nic.macAddress,
                                     enabled=nic.connected,

--- a/templates/netbox.py
+++ b/templates/netbox.py
@@ -269,7 +269,7 @@ class Templates:
             }
         return remove_empty_fields(obj)
 
-    def device_interface(self, device, name, itype, enabled=None, mtu=None,
+    def device_interface(self, device, name, itype=None, enabled=None, mtu=None,
                          mac_address=None, mgmt_only=None, description=None,
                          cable=None, mode=None, untagged_vlan=None,
                          tagged_vlans=None, tags=None):
@@ -281,7 +281,7 @@ class Templates:
         :param name: Name of the physical interface
         :type name: str
         :param itype: Type of interface `0` if Virtual else `32767` for Other
-        :type itype: int
+        :type itype: int,optional
         :param enabled: `True` if the interface is up else `False`
         :type enabled: bool,optional
         :param mtu: The configured MTU for the interface
@@ -674,7 +674,7 @@ class Templates:
             }
         return remove_empty_fields(obj)
 
-    def vm_interface(self, virtual_machine, name, itype=0, enabled=None,
+    def vm_interface(self, virtual_machine, name, enabled=None,
                      mtu=None, mac_address=None, description=None, mode=None,
                      untagged_vlan=None, tagged_vlans=None, tags=None):
         """
@@ -684,8 +684,6 @@ class Templates:
         :type virtual_machine: str
         :param name: Name of the physical interface
         :type name: str
-        :param itype: Type of interface `0` if Virtual else `32767` for Other
-        :type itype: str, optional
         :param enabled: `True` if the interface is up else `False`
         :type enabled: bool,optional
         :param mtu: The configured MTU for the interface
@@ -693,9 +691,7 @@ class Templates:
         :param mac_address: The MAC address of the interface
         :type mac_address: str, optional
         :param description: Description for the interface
-        :itype description: str, optional
         :param mode: `100` if access, `200` if tagged, or `300 if` tagged for all vlans
-        :itype mode: int, optional
         :param untagged_vlan: NetBox VLAN object id of untagged vlan
         :type untagged_vlan: int, optional
         :param tagged_vlans: List of NetBox VLAN object ids for tagged VLANs
@@ -706,11 +702,6 @@ class Templates:
         obj = {
             "virtual_machine": {"name": truncate(virtual_machine, max_len=64)},
             "name": name,
-            "itype": self._version_dependent(
-                nb_obj_type="interfaces",
-                key="type",
-                value=itype
-                ),
             "enabled": enabled,
             "mtu": mtu,
             "mac_address": mac_address.upper() if mac_address else None,


### PR DESCRIPTION
Upon running a vcenter sync, the interfaces of virtual machine objects would always be updated with a PATCH, but without making any real changes.
The change would be visible in the GUI but without any difference.

Also, the interface type on a vm_interface is removed in Netbox 2.9, since this is always virtual.

GET /api/virtualization/interfaces/1924/
```
{
  "id": 1924,
  "virtual_machine": {
    "id": 836,
    "url": "https://netbox.masked-ops.net/api/virtualization/virtual-machines/836/",
    "name": "masked-virtual_machine"
  },
  "name": "vNIC0",
  "type": {
    "value": "virtual",
    "label": "Virtual"
  },
  "enabled": true,
  "mtu": null,
  "mac_address": "00:50:56:98:00:BF",
  "description": "",
  "mode": null,
  "untagged_vlan": null,
  "tagged_vlans": [],
  "tags": [
    "vCenter",
    "Synced",
    "masked-vcenter006"
  ]
}
```

Debug log upon sync doing a unnecessary PATCH, changing nothing, but reporting a change:
```
[DEBUG] Sending GET to 'https://netbox.masked-ops.net/api/virtualization/interfaces/?virtual_machine=masked-virtual_machine&name=vNIC0&?tag=masked-vcenter006' with data 'None'.
[DEBUG] Received HTTP Status 200.
[DEBUG] NetBox GET request OK; returned 200 status.
[DEBUG] NetBox virtual_interfaces object 'vNIC0' already exists. Comparing values.
[DEBUG] vc_data[virtual_machine] and nb_data[virtual_machine] contain dictionary. Evaluating.
[DEBUG] vc_data[virtual_machine][name] and nb_data[virtual_machine][name] values match.
[DEBUG] Final dictionary compare result: True
[DEBUG] vc_data[virtual_machine] and nb_data[virtual_machine] values match.
[DEBUG] vc_data[name] and nb_data[name] values match.
[DEBUG] vc_data[itype] not a valid key in nb_data[itype].
[DEBUG] vc_data[itype] and nb_data[itype] values do not match.
[INFO] NetBox virtual_interfaces object 'vNIC0' do not match current values.
[DEBUG] Merging tags between vCenter and NetBox object.
[DEBUG] Sending PATCH to 'https://netbox.masked-ops.net/api/virtualization/interfaces/1924/' with data '{'virtual_machine': {'name': 'masked-virtual_machine'}, 'name': 'vNIC0', 'itype': 'virtual', 'enabled': True, 'mac_address': '00:50:56:98:00:BF', 'tags': ['masked-vcenter006', 'vCenter', 'Synced']}'.
[DEBUG] Received HTTP Status 200.
[DEBUG] NetBox PATCH request OK; returned 200 status.
```
